### PR TITLE
remove fideloper/proxy from deps

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
   ],
   "minimum-stability": "dev",
   "require": {
-    "fideloper/proxy": "^4.0",
     "guzzlehttp/guzzle": "^6.3|^7.0",
     "illuminate/contracts": "~7.0|~8.0|~9.0|~10.0",
     "illuminate/support": "~7.0|~8.0|~9.0|~10.0"


### PR DESCRIPTION
As of laravel 9 this package is not needed anymore as it is builded in